### PR TITLE
Support wildcards in Time patterns

### DIFF
--- a/lib/ruy/time_pattern.rb
+++ b/lib/ruy/time_pattern.rb
@@ -4,46 +4,81 @@ module Ruy
   class TimePattern
     include Comparable
 
-    WELL_FORMED_TS_EXP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(z(\S+))?$/
+    WELL_FORMED_TS_EXP = /^(?<year>\d{4}|\*)-(?<month>\d{2}|\*)-(?<day>\d{2}|\*)T(?<hour>\d{2}|\*):(?<minute>\d{2}|\*):(?<second>\d{2}|\*)(z(?<time_zone>\S+))?$/
 
-    attr_reader :tz, :local_time, :utc_time
+    attr_reader :year, :month, :day, :hour, :min, :sec, :time_zone, :tz, :local, :utc, :utc_offset
 
     # @param [String] pattern String representing a Ruy's well-formed timestamp pattern
     # @param [String] tz_identifier String representing IANA's time zone identifier. Defaults to UTC if none passed.
     def initialize(pattern, tz_identifier = 'UTC')
       raise ArgumentError, 'Pattern is malformed' unless match_data = pattern.match(WELL_FORMED_TS_EXP)
 
-      year = match_data[1].to_i
-      month = match_data[2].to_i
-      day = match_data[3].to_i
-      hours = match_data[4].to_i
-      min = match_data[5].to_i
-      sec = match_data[6].to_i
-      tz_identifier = match_data[8] || tz_identifier
+      @pattern = pattern
+
+      @year = match_data[:year] == '*' ? nil : match_data[:year].to_i
+      @month = match_data[:month] == '*' ? nil : match_data[:month].to_i
+      @day = match_data[:day] == '*' ? nil : match_data[:day].to_i
+      @hour = match_data[:hour] == '*' ? nil : match_data[:hour].to_i
+      @min = match_data[:minute] == '*' ? nil : match_data[:minute].to_i
+      @sec = match_data[:second] == '*' ? nil : match_data[:second].to_i
+      @time_zone = match_data[:time_zone]
 
       # Store the TZInfo::Timezone object corresponding to the specified time zone
-      @tz = TZInfo::Timezone.get(tz_identifier)
+      @tz = TZInfo::Timezone.get(@time_zone || tz_identifier)
 
       # Store a Time object with values based on the specified time zone
-      @local_time = Time.new(year, month, day, hours, min, sec, '+00:00')
+      @local = Time.new(year || 0, month, day, hour, min, sec, '+00:00')
 
       # Store a Time object with values based on UTC
-      @utc_time = @tz.local_to_utc(@local_time)
+      @utc = @tz.local_to_utc(@local)
+      @utc_offset = @tz.current_period.utc_total_offset
     end
 
-    # Implements Ruby's spaceship operator to work with TimePattern objects.
+    # Implements Ruby's spaceship operator to work with Time objects.
+    #   Uses Object's spaceship operator if passed object does not respond to #to_time.
     #
-    # @param [TimePattern|Time]
+    # @param [#to_time]
     # @return [Fixnum]
-    def <=>(time)
-      @utc_time <=> (time.is_a?(self.class) ? time.utc_time : time)
+    def <=>(o)
+      if o.respond_to?(:to_time)
+        time = o.to_time
+        time_to_local = @tz.utc_to_local(time.utc)
+
+        self_time = Time.gm(
+          self.year  || time_to_local.year,
+          self.month || time_to_local.month,
+          self.day   || time_to_local.day,
+          self.hour  || time_to_local.hour,
+          self.min   || time_to_local.min,
+          self.sec   || time_to_local.sec,
+          Rational(time_to_local.nsec, 1000)
+          )
+
+        @tz.local_to_utc(self_time) <=> time
+
+      else
+        super
+      end
+    end
+
+    # Overrides Object equal operator and uses Comparable equality for Time objects.
+    #   Uses identity comparison if passed object does not respond to #to_time.
+    #
+    # @param [#to_time]
+    # @return [Boolean]
+    def ==(o)
+      if o.respond_to?(:to_time)
+        super
+      else
+        equal?(o)
+      end
     end
 
     # Returns a well-formed Ruy timestamp with IANA time zone identifier representing the current TimePattern object.
     #
     # @return [String]
     def to_s
-      @local_time.strftime("%Y-%m-%dT%H:%M:%Sz#{@tz.identifier}")
+      @pattern
     end
 
     # Overrides Ruby's method missing call to redirect calls to the stored Time object in case it responds to the
@@ -51,7 +86,8 @@ module Ruy
     #
     # @param (see BasicObject#method_missing)
     def method_missing(method, *args)
-      @utc_time.respond_to?(method) ? @utc_time.send(method, *args) : super
+      @utc.respond_to?(method) ? @utc.send(method, *args) : super
     end
+
   end
 end

--- a/spec/lib/ruy/conditions/tz_spec.rb
+++ b/spec/lib/ruy/conditions/tz_spec.rb
@@ -68,6 +68,14 @@ describe Ruy::Conditions::TZ do
       it_behaves_like 'tz wrapped matchers'
     end
 
+    context 'values have wildcards' do
+      let(:value) { "2014-12-*T*:*:*z#{tz_identifier}" }
+      let(:left_value) { "*-11-*T*:*:*z#{tz_identifier}" }
+      let(:right_value) { "2014-*-*T22:*:00z#{tz_identifier}" }
+
+      it_behaves_like 'tz wrapped matchers'
+    end
+
     context 'values don\'t have their time zone identifiers' do
       let(:value) { "2014-12-31T21:00:00" }
       let(:left_value) { "2014-12-31T20:00:00" }

--- a/spec/lib/ruy/time_pattern_spec.rb
+++ b/spec/lib/ruy/time_pattern_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 describe Ruy::TimePattern do
   let(:time_zone_identifier) { 'America/Argentina/Buenos_Aires' }
   let(:timestamp) { "2014-12-31T23:59:59z#{time_zone_identifier}" }
+  let(:tz) { TZInfo::Timezone.get(time_zone_identifier) }
   let(:local_time) { Time.new(2014, 12, 31, 23, 59, 59, '+00:00') }
-  let(:utc_time) { TZInfo::Timezone.get(time_zone_identifier).local_to_utc local_time }
+  let(:utc_time) { tz.local_to_utc local_time }
 
   subject { described_class.new(timestamp) }
 
   describe 'parser' do
-    context 'pattern is a timestamp' do
+    context 'pattern is a full timestamp' do
       context 'timestamp specifies a time zone' do
         context 'default time zone argument is not passed' do
           it 'parses a time zoned timestamp' do
@@ -17,7 +18,7 @@ describe Ruy::TimePattern do
           end
 
           it 'has the correct time zone identifier' do
-            expect(subject.tz.identifier).to eq time_zone_identifier
+            expect(subject.time_zone).to eq time_zone_identifier
           end
         end
 
@@ -31,21 +32,21 @@ describe Ruy::TimePattern do
           end
 
           it 'ignores the default time zone argument' do
-            expect(subject.tz.identifier).to eq time_zone_identifier
+            expect(subject.time_zone).to eq time_zone_identifier
           end
         end
       end
 
       context 'timestamp does not specify a time zone' do
-        let(:timestamp) { '2014-12-31T23:59:59'  }
+        let(:timestamp) { '2014-12-31T23:59:59' }
 
         context 'default time zone argument is not passed' do
           it 'parses a timestamp without time zone' do
             expect(subject).to be_kind_of described_class
           end
 
-          it 'has UTC as time zone identifier' do
-            expect(subject.tz.identifier).to eq 'UTC'
+          it 'does not have a time zone' do
+            expect(subject.time_zone).to be_nil
           end
         end
 
@@ -64,28 +65,115 @@ describe Ruy::TimePattern do
         end
       end
 
-      it 'has the correct year in utc' do
-        expect(subject.year).to eq utc_time.year
+      it 'has the correct year' do
+        expect(subject.year).to eq 2014
       end
 
-      it 'has the correct month in utc' do
-        expect(subject.month).to eq utc_time.month
+      it 'has the correct month' do
+        expect(subject.month).to eq 12
       end
 
-      it 'has the correct day in utc' do
-        expect(subject.day).to eq utc_time.day
+      it 'has the correct day' do
+        expect(subject.day).to eq 31
       end
 
-      it 'has the correct hours in utc' do
-        expect(subject.hour).to eq utc_time.hour
+      it 'has the correct hours' do
+        expect(subject.hour).to eq 23
       end
 
-      it 'has the correct minutes in utc' do
-        expect(subject.min).to eq utc_time.min
+      it 'has the correct minutes' do
+        expect(subject.min).to eq 59
       end
 
-      it 'has the correct seconds in utc' do
-        expect(subject.sec).to eq utc_time.sec
+      it 'has the correct seconds' do
+        expect(subject.sec).to eq 59
+      end
+
+      it 'has the correct utc offset' do
+        expect(subject.utc_offset).to eq tz.current_period.utc_total_offset
+      end
+
+      it 'has the correct local time' do
+        expect(subject.local).to eq local_time
+      end
+
+      it 'has the correct utc time' do
+        expect(subject.utc).to eq utc_time
+      end
+
+    end
+
+    context 'pattern contains wildcards' do
+      context 'with undefined year' do
+        let(:timestamp) { '*-12-31T23:59:59' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define a year' do
+          expect(subject.year).to be_nil
+        end
+      end
+
+      context 'with undefined month' do
+        let(:timestamp) { '2014-*-31T23:59:59' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define a month' do
+          expect(subject.month).to be_nil
+        end
+      end
+
+      context 'with undefined day' do
+        let(:timestamp) { '2014-12-*T23:59:59' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define a day' do
+          expect(subject.day).to be_nil
+        end
+      end
+
+      context 'with undefined hour' do
+        let(:timestamp) { '2014-12-31T*:59:59' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define an hour' do
+          expect(subject.hour).to be_nil
+        end
+      end
+
+      context 'with undefined minute' do
+        let(:timestamp) { '2014-12-31T23:*:59' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define a minute' do
+          expect(subject.min).to be_nil
+        end
+      end
+
+      context 'with undefined second' do
+        let(:timestamp) { '2014-12-31T23:59:*' }
+
+        it 'parses a time zoned timestamp' do
+          expect(subject).to be_kind_of described_class
+        end
+
+        it 'does not define a second' do
+          expect(subject.sec).to be_nil
+        end
       end
 
     end
@@ -100,315 +188,211 @@ describe Ruy::TimePattern do
   end
 
   describe '#to_s' do
-    it 'returns the corresponding ruy well-formed timestamp' do
-      expect(subject.to_s).to eq timestamp
+    context 'pattern is a full timestamp' do
+      it 'returns the corresponding well-formed timestamp' do
+        expect(subject.to_s).to eq timestamp
+      end
+    end
+
+    context 'pattern contains wildcards' do
+      context 'with undefined year' do
+        let(:timestamp) { '*-12-31T23:59:59zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined month' do
+        let(:timestamp) { '2014-*-31T23:59:59zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined day' do
+        let(:timestamp) { '2014-12-*T23:59:59zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined hour' do
+        let(:timestamp) { '2014-12-31T*:59:59zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined minute' do
+        let(:timestamp) { '2014-12-31T23:*:59zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined second' do
+        let(:timestamp) { '2014-12-31T23:59:*zAmerica/Argentina/Buenos_Aires' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq timestamp
+        end
+      end
+
+      context 'with undefined time zone' do
+        let(:timestamp) { '2014-12-31T23:59:59' }
+
+        it 'returns the corresponding well-formed timestamp' do
+          expect(subject.to_s).to eq "#{timestamp}"
+        end
+      end
+    end
+
+    context 'pattern does not have a time zone' do
+      let(:timestamp) { '2014-12-31T23:59:59' }
+
+      it 'returns the corresponding well-formed timestamp' do
+        expect(subject.to_s).to eq timestamp
+      end
     end
   end
 
-  describe 'comparison operators' do
-    let(:equal_time) { utc_time }
-    let(:future_time) { equal_time + 1 }
-    let(:past_time) { equal_time - 1 }
+  shared_examples_for 'time pattern comparison' do
+    context 'subject is a full timestamp' do
+      subject { described_class.new("2014-12-31T23:00:00z#{time_zone_identifier}") }
 
-    let(:equal_time_pattern) { described_class.new(timestamp) }
-    let(:newer_time_pattern) { described_class.new("2015-01-01T00:00:00zAmerica/Argentina/Buenos_Aires") }
-    let(:older_time_pattern) { described_class.new("2014-12-31T23:59:58zAmerica/Argentina/Buenos_Aires") }
+      context 'object is a time' do
+        context 'object is greater than subject' do
+          let(:object) { Time.new(2015, 1, 1, 2, 0, 1, '+00:00') }
 
-    describe '#<=>' do
-      context 'passing a time object' do
-        context 'with an equal time' do
-          it 'returns 0' do
-            expect(subject <=> equal_time).to eq 0
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_greater_than
           end
         end
 
-        context 'with a future time' do
-          it 'returns -1' do
-            expect(subject <=> future_time).to eq -1
+        context 'object is equal to subject' do
+          let(:object) { Time.new(2015, 1, 1, 2, 0, 0, '+00:00') }
+
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_equal_to
           end
         end
 
-        context 'with a past time' do
-          it 'returns 1' do
-            expect(subject <=> past_time).to eq 1
-          end
-        end
-      end
+        context 'object is less than subject' do
+          let(:object) { Time.new(2015, 1, 1, 1, 59, 59, '+00:00') }
 
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns 0' do
-            expect(subject <=> equal_time_pattern).to eq 0
-          end
-        end
-
-        context 'with a newer time pattern' do
-          it 'returns -1' do
-            expect(subject <=> newer_time_pattern).to eq -1
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns 1' do
-            expect(subject <=> older_time_pattern).to eq 1
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_less_than
           end
         end
       end
     end
 
-    describe '#>' do
-      context 'passing a time object' do
-        context 'with an equal time' do
-          it 'returns a falsey value' do
-            expect(subject > equal_time).to be_falsey
+    context 'subject contains wildcards' do
+      subject { described_class.new("*-11-*T23:*:*z#{time_zone_identifier}") }
+
+      context 'object is a time' do
+        context 'object is greater than subject' do
+          let(:object) { Time.new(2015, 1, 1, 2, 0, 1, '+00:00') }
+
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_greater_than
           end
         end
 
-        context 'with a past time' do
-          it 'returns a truthy value' do
-            expect(subject > past_time).to be_truthy
+        context 'object is equal to subject' do
+          let(:object) { Time.new(2014, 12, 1, 2, 0, 0, '+00:00') }
+
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_equal_to
           end
         end
 
-        context 'with a future time' do
-          it 'returns a falsey value' do
-            expect(subject > future_time).to be_falsey
-          end
-        end
-      end
+        context 'object is less than subject' do
+          let(:object) { Time.new(2014, 11, 1, 2, 0, 0, '+00:00') }
 
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a falsey value' do
-            expect(subject > equal_time_pattern).to be_falsey
-          end
-        end
-
-        context 'with a newer time pattern' do
-          it 'returns a falsey value' do
-            expect(subject > newer_time_pattern).to be_falsey
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns a truthy value' do
-            expect(subject > older_time_pattern).to be_truthy
+          it 'evaluates to the expected value' do
+            expect(subject.send(method, object)).to eq expected_value_for_less_than
           end
         end
       end
     end
 
-    describe '#>=' do
-      context 'passing a time object' do
-        context 'with an equal time' do
-          it 'returns a truthy value' do
-            expect(subject >= equal_time).to be_truthy
-          end
-        end
+  end
 
-        context 'with a future time' do
-          it 'returns a falsey value' do
-            expect(subject >= future_time).to be_falsey
-          end
-        end
+  describe '#<=>' do
+    let(:method) { '<=>' }
+    let(:expected_value_for_greater_than) { -1 }
+    let(:expected_value_for_equal_to) { 0 }
+    let(:expected_value_for_less_than) { 1 }
 
-        context 'with a past time' do
-          it 'returns a truthy value' do
-            expect(subject >= past_time).to be_truthy
-          end
-        end
-      end
+    it_behaves_like 'time pattern comparison'
 
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a truthy value' do
-            expect(subject >= equal_time_pattern).to be_truthy
-          end
-        end
+    context 'comparing against a non-time object' do
+      let(:object) { 1 }
 
-        context 'with a newer time pattern' do
-          it 'returns a falsey value' do
-            expect(subject >= newer_time_pattern).to be_falsey
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns a truthy value' do
-            expect(subject >= older_time_pattern).to be_truthy
-          end
-        end
+      it 'returns nil' do
+        expect(subject <=> object).to be_nil
       end
     end
+  end
 
-    describe '#<' do
-      context 'passing a time object' do
-        context 'with an equal time' do
-          it 'returns a falsey value' do
-            expect(subject < equal_time).to be_falsey
-          end
-        end
+  describe '#>' do
+    let(:method) { '>' }
+    let(:expected_value_for_greater_than) { false }
+    let(:expected_value_for_equal_to) { false }
+    let(:expected_value_for_less_than) { true }
 
-        context 'with a future time' do
-          it 'returns truthy value' do
-            expect(subject < future_time).to be_truthy
-          end
-        end
+    it_behaves_like 'time pattern comparison'
+  end
 
-        context 'with a past time' do
-          it 'returns a falsey value' do
-            expect(subject < past_time).to be_falsey
-          end
-        end
-      end
+  describe '#>=' do
+    let(:method) { '>=' }
+    let(:expected_value_for_greater_than) { false }
+    let(:expected_value_for_equal_to) { true }
+    let(:expected_value_for_less_than) { true }
 
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a falsey value' do
-            expect(subject < equal_time_pattern).to be_falsey
-          end
-        end
+    it_behaves_like 'time pattern comparison'
+  end
 
-        context 'with a newer time pattern' do
-          it 'returns a truthy value' do
-            expect(subject < newer_time_pattern).to be_truthy
-          end
-        end
+  describe '#<' do
+    let(:method) { '<' }
+    let(:expected_value_for_greater_than) { true }
+    let(:expected_value_for_equal_to) { false }
+    let(:expected_value_for_less_than) { false }
 
-        context 'with an older time pattern' do
-          it 'returns a falsey value' do
-            expect(subject < older_time_pattern).to be_falsey
-          end
-        end
-      end
+    it_behaves_like 'time pattern comparison'
+  end
 
-    end
+  describe '#<=' do
+    let(:method) { '<=' }
+    let(:expected_value_for_greater_than) { true }
+    let(:expected_value_for_equal_to) { true }
+    let(:expected_value_for_less_than) { false }
 
-    describe '#<=' do
-      context 'passing a time object' do
-        context 'with an equal time' do
-          it 'returns a truthy value' do
-            expect(subject <= equal_time).to be_truthy
-          end
-        end
+    it_behaves_like 'time pattern comparison'
+  end
 
-        context 'with a future time' do
-          it 'returns truthy value' do
-            expect(subject <= future_time).to be_truthy
-          end
-        end
+  describe '#==' do
+    let(:method) { '==' }
+    let(:expected_value_for_greater_than) { false }
+    let(:expected_value_for_equal_to) { true }
+    let(:expected_value_for_less_than) { false }
 
-        context 'with a past time' do
-          it 'returns a falsey value' do
-            expect(subject <= past_time).to be_falsey
-          end
-        end
-      end
+    it_behaves_like 'time pattern comparison'
+  end
 
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a truthy value' do
-            expect(subject <= equal_time_pattern).to be_truthy
-          end
-        end
+  describe '#!=' do
+    let(:method) { '!=' }
+    let(:expected_value_for_greater_than) { true }
+    let(:expected_value_for_equal_to) { false }
+    let(:expected_value_for_less_than) { true }
 
-        context 'with a newer time pattern' do
-          it 'returns a truthy value' do
-            expect(subject <= newer_time_pattern).to be_truthy
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns a falsey value' do
-            expect(subject <= older_time_pattern).to be_falsey
-          end
-        end
-      end
-    end
-
-    describe '#==' do
-      context 'passing a time object' do
-        context 'passing an equal time' do
-          it 'returns a truthy value' do
-            expect(subject == equal_time).to be_truthy
-          end
-        end
-
-        context 'passing a future time' do
-          it 'returns a falsey value' do
-            expect(subject == future_time).to be_falsey
-          end
-        end
-
-        context 'passing a past time' do
-          it 'returns a falsey value' do
-            expect(subject == past_time).to be_falsey
-          end
-        end
-      end
-
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a truthy value' do
-            expect(subject == equal_time_pattern).to be_truthy
-          end
-        end
-
-        context 'with a newer time pattern' do
-          it 'returns a falsey value' do
-            expect(subject == newer_time_pattern).to be_falsey
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns a falsey value' do
-            expect(subject == older_time_pattern).to be_falsey
-          end
-        end
-      end
-    end
-
-    describe '#!=' do
-      context 'passing a time object' do
-        context 'passing an equal time' do
-          it 'returns a falsey value' do
-            expect(subject != equal_time).to be_falsey
-          end
-        end
-
-        context 'passing a future time' do
-          it 'returns a truthy value' do
-            expect(subject != future_time).to be_truthy
-          end
-        end
-
-        context 'passing a past time' do
-          it 'returns a truthy value' do
-            expect(subject != past_time).to be_truthy
-          end
-        end
-      end
-
-      context 'passing a time pattern object' do
-        context 'with an equal time pattern' do
-          it 'returns a falsey value' do
-            expect(subject != equal_time_pattern).to be_falsey
-          end
-        end
-
-        context 'with a newer time pattern' do
-          it 'returns a truthy value' do
-            expect(subject != newer_time_pattern).to be_truthy
-          end
-        end
-
-        context 'with an older time pattern' do
-          it 'returns a truthy value' do
-            expect(subject != older_time_pattern).to be_truthy
-          end
-        end
-      end
-    end
-
+    it_behaves_like 'time pattern comparison'
   end
 
 end


### PR DESCRIPTION
- Discontinue support for TimePattern-TimePattern comparisons
- Call 'super' on compare when passed object does not respond to to_time
- Rewrite test suite to match new behavior
