### PR TITLE
Fix TZInfo version error in .gemspec

### DIFF
--- a/ruy.gemspec
+++ b/ruy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://moove-it.github.io/ruy/'
   s.email       = 'ruy@moove-it.com'
 
-  s.add_runtime_dependency 'tzinfo', '~> 0'
+  s.add_runtime_dependency 'tzinfo', '~> 1'
 
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'simplecov', '0.10.0'


### PR DESCRIPTION
~> 0 would not allow versions of TZInfo greater than 1.x.x to work. In fact, Bundler will fail to install ruy on gem sets including Rails 4 because it requires TZInfo 1.2.2.